### PR TITLE
Phase 0: Add Go shared imports for patron/harvester rollout

### DIFF
--- a/.github/workflows/shared/go-ci.md
+++ b/.github/workflows/shared/go-ci.md
@@ -1,0 +1,65 @@
+---
+# Go CI Shared Import
+# Standardized Go CI execution shape for Taskfile-based repos
+#
+# Usage:
+#   imports:
+#     - shared/go-ci.md
+#
+# This import provides:
+# - Go version detection from go.mod
+# - Standardized Taskfile task names for lint, test, and CI
+# - Network allowlist for Go module proxy and checksum database
+#
+# Note: This import does NOT define lint rules. Each repo maintains
+# its own .golangci.yml with repo-specific linter configuration.
+# Patron uses 50+ linters; harvester uses 39 linters.
+
+network:
+  allowed:
+    - defaults
+    - proxy.golang.org
+    - sum.golang.org
+    - pkg.go.dev
+
+tools:
+  bash:
+    - "go *"
+    - "task *"
+    - "git"
+---
+
+# Go CI Environment
+
+This repo uses [Task](https://taskfile.dev/) as the build system. All CI operations are invoked through Taskfile targets.
+
+## Go Version Detection
+
+```bash
+# Detect Go version from go.mod
+go mod edit -json | jq -r .Go
+```
+
+## Standard Task Targets
+
+| Target | Purpose |
+|--------|---------|
+| `task lint` | Run golangci-lint with repo-local config |
+| `task test` | Run unit tests with race detector |
+| `task testint` | Run integration tests |
+| `task ci` | Full CI pipeline (lint + test) |
+| `task fmt` | Format Go source files |
+| `task deps-start` | Start Docker dependencies for integration tests |
+| `task deps-stop` | Stop Docker dependencies |
+
+## Lint Configuration
+
+Each repository maintains its own `.golangci.yml`. This shared import does not override or define lint rules. Reference the repo-local config for the active linter set.
+
+## Network Access
+
+The following domains are allowed for Go module operations:
+
+- `proxy.golang.org` — Go module proxy
+- `sum.golang.org` — Go checksum database
+- `pkg.go.dev` — Go package documentation (read-only reference)

--- a/.github/workflows/shared/go-security.md
+++ b/.github/workflows/shared/go-security.md
@@ -1,0 +1,93 @@
+---
+# Go Security Scanning Shared Import
+# Guidance for govulncheck and gosec in Go repositories
+#
+# Usage:
+#   imports:
+#     - shared/go-security.md
+#
+# This import provides:
+# - govulncheck invocation and output parsing
+# - gosec invocation with JSON output and severity bucketing
+# - Dependency audit patterns for go.mod / go.sum changes
+# - Network allowlist for vuln.go.dev
+#
+# Repo baselines:
+# - Patron: already gets gosec signal through golangci-lint integration
+# - Harvester: should rely on this import for explicit security scanning
+
+network:
+  allowed:
+    - defaults
+    - vuln.go.dev
+    - proxy.golang.org
+    - sum.golang.org
+
+tools:
+  bash:
+    - "go *"
+    - "govulncheck *"
+    - "gosec *"
+    - "jq *"
+    - "git"
+---
+
+# Go Security Scanning
+
+## govulncheck
+
+Scan for known vulnerabilities in Go dependencies and source code.
+
+```bash
+# Install
+go install golang.org/x/vuln/cmd/govulncheck@latest
+
+# Run against all packages
+govulncheck ./...
+```
+
+Output includes:
+- Vulnerability ID (e.g., GO-2024-XXXX)
+- Affected module and version
+- Whether the vulnerable symbol is actually called in code
+
+## gosec
+
+Scan Go source for common security issues.
+
+```bash
+# Install
+go install github.com/securego/gosec/v2/cmd/gosec@latest
+
+# Run with JSON output for structured processing
+gosec -fmt json -out /tmp/gh-aw/gosec-results.json ./...
+```
+
+## Severity Bucketing
+
+When reporting findings, classify by severity:
+
+| Severity | Action | SLA |
+|----------|--------|-----|
+| Critical | Immediate issue, label `P0-critical` | 24h |
+| High | Issue with `P1-high`, assign owner | 7 days |
+| Medium | Issue with `P2-medium` | 30 days |
+| Low | Track only, no issue unless pattern | — |
+
+## Dependency Audit
+
+Check `go.mod` and `go.sum` for problematic patterns:
+
+```bash
+# List all direct dependencies with versions
+go list -m -json all | jq -r 'select(.Indirect != true) | "\(.Path) \(.Version)"'
+
+# Check for replaced modules (potential supply chain concern)
+go mod edit -json | jq -r '.Replace[]? | "\(.Old.Path) -> \(.New.Path)"'
+```
+
+## Network Access
+
+- `vuln.go.dev` — Go vulnerability database
+- `proxy.golang.org` — Module downloads for analysis
+- `sum.golang.org` — Checksum verification

--- a/.github/workflows/shared/issue-triage-go.md
+++ b/.github/workflows/shared/issue-triage-go.md
@@ -1,0 +1,86 @@
+---
+# Go Issue Triage Shared Import
+# Label taxonomy and classification logic for Go repositories
+#
+# Usage:
+#   imports:
+#     - shared/issue-triage-go.md
+#
+# This import provides:
+# - Standardized label taxonomy for Go repos
+# - Go-specific issue pattern matching rules
+# - Duplicate detection heuristics
+# - Staleness and auto-close criteria
+#
+# Repo context:
+# - Patron already has an Issue Triage Agent using this taxonomy
+# - Harvester is the primary new deployment target
+# - This import ensures consistent labeling across both repos
+---
+
+# Go Issue Triage Rules
+
+## Label Taxonomy
+
+### Type Labels
+| Label | When to apply |
+|-------|--------------|
+| `bug` | Confirmed or suspected defect: panics, nil pointers, incorrect behavior |
+| `enhancement` | Improvement to existing functionality |
+| `feature` | New capability request |
+| `question` | Seeking clarification or usage help |
+| `documentation` | Missing, incorrect, or unclear docs |
+| `performance` | Slowness, excessive memory/CPU, inefficient patterns |
+
+### Area Labels
+| Label | When to apply |
+|-------|--------------|
+| `api` | Exported types, interfaces, or function signatures |
+| `core` | Internal implementation, non-exported code |
+| `deps` | Dependency versions, go.mod changes, module conflicts |
+| `ci` | CI pipeline, GitHub Actions, build system |
+| `test` | Test failures, coverage gaps, test infrastructure |
+
+### Priority Labels
+| Label | Criteria |
+|-------|----------|
+| `P0-critical` | Data loss, security vulnerability, complete breakage |
+| `P1-high` | Panic/nil pointer, broken core functionality |
+| `P2-medium` | Degraded functionality, workaround exists |
+| `P3-low` | Cosmetic, minor inconvenience, nice-to-have |
+
+### Status Labels
+| Label | Purpose |
+|-------|---------|
+| `needs-info` | Issue lacks reproduction steps or environment details |
+| `good-first-issue` | Clear scope, well-defined, suitable for newcomers |
+| `help-wanted` | Maintainer cannot prioritize, community contribution welcome |
+| `wontfix` | Intentional behavior or out of scope |
+
+## Go-Specific Pattern Matching
+
+Apply these rules based on issue content:
+
+| Signal in issue | Type | Priority |
+|----------------|------|----------|
+| Panic, nil pointer, segfault | `bug` | `P1-high` |
+| `go.mod`, `go.sum`, dependency version | `deps` | `P2-medium` |
+| Exported type/interface change | `api` | Flag for breaking change review |
+| Test failure, coverage drop | `test` | `P2-medium` |
+| Slow, timeout, memory leak | `performance` | `P2-medium` |
+| "How do I", "is it possible" | `question` | `P3-low` |
+
+## Duplicate Detection
+
+Before labeling, check for similar existing issues:
+1. Compare title against the last 30 open issues using keyword overlap
+2. If >70% keyword match, add a comment linking to the potential duplicate
+3. Do NOT auto-close — let the maintainer decide
+
+## Staleness Criteria
+
+| Condition | Action |
+|-----------|--------|
+| >90 days inactive + `P3-low` | Add `stale` label, comment warning |
+| >180 days inactive + `P3-low` + no activity after warning | Close with explanation |
+| Has `keep-open` label | Exempt from staleness rules |

--- a/.github/workflows/shared/mood.md
+++ b/.github/workflows/shared/mood.md
@@ -1,1 +1,32 @@
-.
+---
+# Agent Personality and Tone
+# Shared across all agentic workflows in beatlabs repos
+#
+# Usage:
+#   imports:
+#     - shared/mood.md
+---
+
+# Communication Style
+
+You are a direct, technical engineer. Follow these rules in all comments, issues, and discussions:
+
+## Tone
+- Concise and evidence-based. State findings, reference specific files and line numbers.
+- No filler words, no corporate hedging, no assistant-style niceties.
+- No emojis in technical analysis. Use them sparingly in status headers only if the existing repo convention does.
+
+## Comment Structure
+1. **Context**: One sentence on what was analyzed and why
+2. **Findings**: Bulleted list with file paths, line numbers, or specific evidence
+3. **Action**: What should happen next — be specific
+
+## When Uncertain
+- Say so explicitly: "Unable to determine X from available context"
+- Apply the `needs-info` label when more detail is required from the issue author
+- Never speculate without evidence or promise fixes
+
+## What Not To Do
+- Do not use phrases like "I'd be happy to", "Great question", "Let me help you with"
+- Do not repeat the issue title or description back to the author
+- Do not add disclaimers about being an AI

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Shared prompt fragments live in `shared/` and are pulled in via the `imports:` f
 | `shared/jqschema.md` | `jq` utilities and schema inference tooling |
 | `shared/reporting.md` | Report formatting guidelines (header levels, progressive disclosure) |
 | `shared/trending-charts-simple.md` | Python chart environment with cache-memory integration for trending data |
+| `shared/go-ci.md` | Go CI context: Taskfile targets, linting config, test commands, network allowlist for Go module proxies |
+| `shared/go-security.md` | Go security scanning guidance: govulncheck, gosec, dependency audit, CVE reporting |
+| `shared/issue-triage-go.md` | Go-specific issue triage taxonomy: component classification, priority rules, label scheme |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
 # aw-common
-Agentic Workflows Common
+
+Common agentic workflows for [gh-aw](https://github.github.com/gh-aw/introduction/overview/) — GitHub's framework for AI-powered workflow automation.
+
+## Structure
+
+Each workflow consists of:
+
+- **`.md`** — The workflow definition: frontmatter (triggers, permissions, tools, imports) + agent prompt
+- **`.lock.yml`** — Auto-generated GitHub Actions file produced by `gh aw compile`. Do not edit manually.
+
+Shared prompt fragments live in `shared/` and are pulled in via the `imports:` frontmatter key.
+
+## Workflows
+
+| Workflow | Schedule | Description |
+|----------|----------|-------------|
+| `org-health-report` | Monthly (1st) | Analyzes issues and PRs across all public org repos, produces health metrics and a discussion report |
+| `stale-repo-identifier` | Monthly (1st) | Scans org repositories for staleness signals and files issues for inactive repos |
+| `ubuntu-image-analyzer` | Monthly (1st) | Analyzes the default Ubuntu Actions runner image and maintains Docker mimic documentation |
+
+## Shared Imports
+
+| Import | Purpose |
+|--------|---------|
+| `shared/mood.md` | Agent personality/tone |
+| `shared/python-dataviz.md` | Python environment setup with NumPy, Pandas, Matplotlib, Seaborn, SciPy + artifact upload |
+| `shared/jqschema.md` | `jq` utilities and schema inference tooling |
+| `shared/reporting.md` | Report formatting guidelines (header levels, progressive disclosure) |
+| `shared/trending-charts-simple.md` | Python chart environment with cache-memory integration for trending data |
+
+## Usage
+
+Workflows are compiled with:
+
+```sh
+gh aw compile
+```
+
+This reads the `.md` definitions and generates the corresponding `.lock.yml` files. The `.gitattributes` marks lock files as `linguist-generated` and uses `merge=ours` to avoid merge conflicts on generated content.


### PR DESCRIPTION
## Summary

Adds shared prompt fragments (imports) to `aw-common` that will be consumed by agentic workflows in **patron** and **harvester** during the phased gh-aw rollout.

## Changes

| File | Status | Purpose |
|------|--------|---------|
| `shared/go-ci.md` | **New** | Go CI context — Taskfile targets, linting config, test commands, network allowlist for Go module proxies |
| `shared/go-security.md` | **New** | Go security scanning — govulncheck, gosec, dependency audit, CVE reporting format |
| `shared/issue-triage-go.md` | **New** | Go issue triage taxonomy — component classification, priority rules, label scheme |
| `shared/mood.md` | **Updated** | Agent communication style — was a placeholder (`.`), now has full tone/structure directives |
| `README.md` | **Updated** | Added new shared imports to the table |

## Context

This is **Phase 0** of the [beatlabs gh-aw rollout plan](https://github.com/beatlabs/aw-common). Subsequent phases will add workflows to patron and harvester that `imports:` these shared fragments.

### Phase overview
- **Phase 0** (this PR): Shared imports in aw-common
- **Phase 1**: Issue Triage + CI Doctor → harvester
- **Phase 2**: Code quality + documentation workflows
- **Phase 3**: Org-level observability + release automation
- **Phase 4**: Advanced patterns (issue-to-PR, PR review)

## QA

- [x] Files follow existing shared import pattern (YAML frontmatter + markdown body)
- [x] README table updated with all new entries
- [x] No workflows modified — imports only, zero runtime impact until consumed