### PR TITLE
Phase 2: Add semver-policy shared import and update README

### DIFF
--- a/.github/workflows/shared/semver-policy.md
+++ b/.github/workflows/shared/semver-policy.md
@@ -1,0 +1,47 @@
+---
+# Semver policy for Go libraries
+# Usage: imports: [shared/semver-policy.md]
+---
+
+# Semantic Versioning Policy for Go Libraries
+
+Apply semantic versioning using Go module conventions.
+
+- Breaking API changes require a new major version.
+- Additive, backward-compatible API changes are minor version changes.
+- Backward-compatible fixes are patch version changes.
+- For Go modules, a major version greater than v1 must follow Go module path conventions.
+
+## Breaking Changes in Go
+
+Treat the following as breaking changes when they affect exported API surface:
+
+- Removed exported functions, methods, types, constants, or variables.
+- Changed function or method signatures, including parameter lists, parameter types, return values, or return types.
+- Removed or renamed exported struct fields.
+- Changed exported struct field types in incompatible ways.
+- Changed interface method sets.
+- Changed exported type definitions in incompatible ways.
+
+## Not Breaking
+
+Do not treat the following as breaking on their own:
+
+- Adding new exported functions, methods, types, constants, or variables.
+- Adding new optional exported struct fields.
+- Adding new implementations of existing interfaces.
+
+## Labels
+
+- Apply `breaking-change` for confirmed breaking API changes.
+- Apply `api-change` for confirmed API surface changes that are not breaking, such as new exports.
+
+## Severity
+
+Classify confirmed changes with this priority:
+
+1. Removal of existing exported API.
+2. Signature or type-shape changes to existing exported API.
+3. Behavioral changes that may alter consumer expectations.
+
+When uncertain, prefer no finding over a speculative finding.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Shared prompt fragments live in `shared/` and are pulled in via the `imports:` f
 
 | Workflow | Schedule | Description |
 |----------|----------|-------------|
-| `org-health-report` | Monthly (1st) | Analyzes issues and PRs across all public org repos, produces health metrics and a discussion report |
+| `org-health-report` | Monthly (1st) | Analyzes issues and PRs for patron and harvester, produces comparative health metrics and an issue report |
 | `stale-repo-identifier` | Monthly (1st) | Scans org repositories for staleness signals and files issues for inactive repos |
 | `ubuntu-image-analyzer` | Monthly (1st) | Analyzes the default Ubuntu Actions runner image and maintains Docker mimic documentation |
 
@@ -31,6 +31,7 @@ Shared prompt fragments live in `shared/` and are pulled in via the `imports:` f
 | `shared/go-ci.md` | Go CI context: Taskfile targets, linting config, test commands, network allowlist for Go module proxies |
 | `shared/go-security.md` | Go security scanning guidance: govulncheck, gosec, dependency audit, CVE reporting |
 | `shared/issue-triage-go.md` | Go-specific issue triage taxonomy: component classification, priority rules, label scheme |
+| `shared/semver-policy.md` | Semantic versioning policy for Go libraries: breaking change definitions, severity classification, labeling rules |
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Phase 2 shared infrastructure for aw-common.

## Changes

### New: `shared/semver-policy.md`
- Semantic versioning policy for Go libraries
- Defines what constitutes a breaking change in Go (removed exports, signature changes, struct field changes, interface changes)
- Defines what is NOT breaking (new exports, new optional fields)
- Severity classification: removal > signature change > behavior change
- Labeling rules: `breaking-change`, `api-change`
- Consumed by patron's `breaking-change-checker` workflow via `imports: [shared/semver-policy.md]`

### Updated: `README.md`
- Added `shared/semver-policy.md` to the shared imports table
- Updated `org-health-report` description to reflect patron+harvester scope (from Phase 1)

## Dependencies

- ✅ Phase 0 and Phase 1 merged
- patron Phase 2 PR imports this shared file

## QA

- [x] Follows existing shared import pattern (minimal YAML frontmatter + markdown body)
- [x] README table renders cleanly with new entry
- [x] No existing files modified (only new file + README update)