### PR TITLE
Phase 3: Observability & release workflows

### DIFF
--- a/.github/workflows/audit-workflows.md
+++ b/.github/workflows/audit-workflows.md
@@ -1,0 +1,105 @@
+---
+description: Audit agentic workflows across the Beatlabs fleet and produce one weekly health report.
+on:
+  schedule:
+    - cron: "0 2 * * 1"
+  workflow_dispatch:
+permissions:
+  contents: read
+  actions: read
+tools:
+  - github[actions, repos]
+  - bash
+imports:
+  - shared/mood.md
+  - shared/reporting.md
+engine: copilot
+strict: true
+timeout-minutes: 30
+safe-outputs:
+  create-issue:
+    title-prefix: "[audit]"
+    labels: ["report", "ci"]
+    max: 1
+    close-older-issues: true
+  upload-asset:
+    max: 3
+---
+
+You are the **Audit Workflows Agent**.
+
+Audit **all agentic workflows** across only these repositories:
+
+- `beatlabs/patron`
+- `beatlabs/harvester`
+- `beatlabs/aw-common`
+
+This is the meta-workflow that keeps the fleet healthy. Run a weekly Monday 2am UTC audit over the last **2 weeks** of workflow run history.
+
+## Fleet Scope
+
+### `beatlabs/patron`
+- `ci-doctor`
+- `issue-triage-agent`
+- `daily-doc-updater`
+- `daily-repo-status`
+- `code-simplifier`
+- `breaking-change-checker`
+- `duplicate-code-detector`
+- `test-improvement-agent`
+
+### `beatlabs/harvester`
+- `issue-triage-agent`
+- `ci-doctor`
+- `code-simplifier`
+- `test-improvement-agent`
+- `daily-doc-updater`
+
+### `beatlabs/aw-common`
+- `org-health-report`
+- `stale-repo-identifier`
+- `ubuntu-image-analyzer`
+- `metrics-collector`
+
+## Audit Requirements
+
+For each workflow in scope, analyze the last **14 days** of run history and determine:
+
+- Run count
+- Success rate
+- Failure rate
+- Average duration
+- Whether it has been triggered at all
+- Whether it is producing expected outputs such as issues, comments, pull requests, or artifacts
+
+## Classification
+
+Classify every workflow into exactly one of these states:
+
+- **Healthy**: Running as expected and producing value
+- **Noisy**: Too many outputs or high false positive rate
+- **Flaky**: Inconsistent success/failure pattern
+- **Silent**: Not triggered or producing no outputs
+- **Costly**: Running too long or too frequently for its value
+
+## Output
+
+Create exactly **one** audit issue that includes:
+
+1. A fleet overview table with:
+   - repository
+   - workflow
+   - status
+   - run count
+   - success rate
+   - average duration
+2. Per-workflow findings for every workflow not classified as **Healthy**
+3. Concrete recommendations for tuning, disabling, or investigating workflows
+
+## Additional Requirements
+
+- Upload the collected run-history data as a JSON artifact
+- Close the previous `[audit]` issue automatically
+- Stay strictly within `beatlabs/patron`, `beatlabs/harvester`, and `beatlabs/aw-common`
+- Do not reference repositories outside this fleet
+- Prefer concise, actionable findings over narrative commentary

--- a/.github/workflows/metrics-collector.md
+++ b/.github/workflows/metrics-collector.md
@@ -1,0 +1,118 @@
+---
+description: Collect daily metrics for patron and harvester and publish structured outputs.
+on:
+  schedule:
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+permissions:
+  contents: read
+  actions: read
+  issues: read
+  pull-requests: read
+tools: github[repos, issues, pull_requests, actions, search], bash, cache-memory
+safe-outputs:
+  upload-asset:
+    max: 10
+  messages:
+    max: 1
+imports:
+  - shared/mood.md
+  - shared/python-dataviz.md
+  - shared/trending-charts-simple.md
+  - shared/jqschema.md
+  - shared/org-metrics-schema.md
+engine: copilot
+strict: true
+timeout-minutes: 45
+network:
+  allowed: [defaults, python]
+---
+
+# Metrics Collector
+
+You are the daily metrics collector for `beatlabs/patron` and `beatlabs/harvester`.
+
+## Goal
+
+Collect daily repository health metrics for exactly these two repositories:
+
+- `beatlabs/patron`
+- `beatlabs/harvester`
+
+Produce structured JSON that conforms exactly to the schema defined in `shared/org-metrics-schema.md`.
+
+## Requirements
+
+1. Create working directories before collecting data:
+
+   ```bash
+   mkdir -p /tmp/gh-aw/metrics
+   mkdir -p /tmp/gh-aw/metrics/charts
+   ```
+
+2. For each repository, gather the following metrics:
+
+   - Issue counts:
+     - `open_issues`
+     - `closed_issues_24h`
+   - Pull request counts:
+     - `open_prs`
+     - `merged_prs_24h`
+     - `pending_reviews`
+   - CI health over the last 7 days:
+     - `ci_pass_rate_7d`
+     - `ci_avg_duration_minutes`
+   - Agentic workflow activity over the last 24 hours:
+     - `agentic_workflow_runs_24h`
+     - `agentic_workflow_success_rate`
+
+3. Add a 5 second delay between repository query groups to reduce rate-limit pressure.
+
+4. Handle empty or missing data gracefully:
+
+   - Use `0` for count fields when no matching records exist.
+   - Use `null` for rate or duration fields when there is insufficient data.
+   - Do not fail the workflow solely because a specific metric source is empty.
+
+5. Build a `cross_repo_summary` object from the per-repo metrics using the shared schema.
+
+6. Save the final JSON payload to:
+
+   ```text
+   /tmp/gh-aw/metrics/daily-YYYY-MM-DD.json
+   ```
+
+   Use the UTC date for `YYYY-MM-DD`.
+
+7. Validate the JSON structure against the shared schema contract before upload.
+
+8. Generate trending charts in Python comparing `beatlabs/patron` and `beatlabs/harvester` using the collected daily metrics and any available cached history.
+
+   Recommended charts:
+
+   - issues and PRs comparison
+   - CI pass rate comparison
+   - workflow activity comparison
+
+   Save charts under `/tmp/gh-aw/metrics/charts/`.
+
+9. Upload outputs via `upload-asset`:
+
+   - the daily JSON file
+   - generated chart images
+
+10. Store trend data in `cache-memory` so future runs can support month-over-month comparison.
+
+## Collection guidance
+
+- Use GitHub repository, issue, pull request, actions, and search capabilities only.
+- Restrict all collection and analysis to `beatlabs/patron` and `beatlabs/harvester`.
+- For pending reviews, count open pull requests that are waiting on reviewer action.
+- For CI metrics, use the last 7 days of relevant workflow runs to compute pass rate and average duration.
+- For agentic workflow metrics, identify relevant workflow runs in the last 24 hours and compute total runs plus success rate.
+- Keep output keys stable because downstream audit and weekly summary workflows depend on them.
+
+## Expected output behavior
+
+- Emit one final structured message summarizing collection success, saved file path, uploaded assets, and any graceful fallbacks used.
+- Ensure the JSON artifact remains the source of truth for downstream consumers.

--- a/.github/workflows/shared/org-metrics-schema.md
+++ b/.github/workflows/shared/org-metrics-schema.md
@@ -1,0 +1,100 @@
+---
+description: Stable schema for daily metrics collected for patron and harvester.
+---
+
+# Organization Metrics Schema
+
+This schema defines the stable JSON contract for daily metrics collected from `beatlabs/patron` and `beatlabs/harvester`.
+
+Downstream consumers such as the audit workflow and weekly summary depend on these keys remaining stable. Do not rename, remove, or repurpose existing keys. Only add new keys in a backward-compatible way.
+
+## Top-level object
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `collection_timestamp` | `string` | Yes | ISO 8601 timestamp for when collection completed. |
+| `repos` | `array<object>` | Yes | Per-repository daily metrics. Current producers emit one entry for `beatlabs/patron` and one entry for `beatlabs/harvester`. |
+| `cross_repo_summary` | `object` | Yes | Aggregated summary across all repositories in `repos`. |
+
+## `repos[]` object
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `repo` | `string` | Yes | Repository identifier. Allowed values for the current producer are `beatlabs/patron` and `beatlabs/harvester`. |
+| `open_issues` | `integer` | Yes | Current count of open issues. |
+| `closed_issues_24h` | `integer` | Yes | Count of issues closed during the last 24 hours. |
+| `open_prs` | `integer` | Yes | Current count of open pull requests. |
+| `merged_prs_24h` | `integer` | Yes | Count of pull requests merged during the last 24 hours. |
+| `pending_reviews` | `integer` | Yes | Count of open pull requests currently waiting on review. |
+| `ci_pass_rate_7d` | `number \| null` | Yes | CI pass rate over the last 7 days, represented as a decimal ratio from `0` to `1`. Use `null` when no qualifying runs exist. |
+| `ci_avg_duration_minutes` | `number \| null` | Yes | Average CI run duration over the last 7 days in minutes. Use `null` when no qualifying runs exist. |
+| `agentic_workflow_runs_24h` | `integer` | Yes | Count of agentic workflow runs during the last 24 hours. |
+| `agentic_workflow_success_rate` | `number \| null` | Yes | Agentic workflow success rate during the last 24 hours, represented as a decimal ratio from `0` to `1`. Use `null` when no qualifying runs exist. |
+
+## `cross_repo_summary` object
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `repo_count` | `integer` | Yes | Number of repository entries included in `repos`. |
+| `total_open_issues` | `integer` | Yes | Sum of `open_issues` across all repositories. |
+| `total_closed_issues_24h` | `integer` | Yes | Sum of `closed_issues_24h` across all repositories. |
+| `total_open_prs` | `integer` | Yes | Sum of `open_prs` across all repositories. |
+| `total_merged_prs_24h` | `integer` | Yes | Sum of `merged_prs_24h` across all repositories. |
+| `total_pending_reviews` | `integer` | Yes | Sum of `pending_reviews` across all repositories. |
+| `avg_ci_pass_rate_7d` | `number \| null` | Yes | Average of non-null `ci_pass_rate_7d` values across repositories. |
+| `avg_ci_duration_minutes` | `number \| null` | Yes | Average of non-null `ci_avg_duration_minutes` values across repositories. |
+| `total_agentic_workflow_runs_24h` | `integer` | Yes | Sum of `agentic_workflow_runs_24h` across all repositories. |
+| `avg_agentic_workflow_success_rate` | `number \| null` | Yes | Average of non-null `agentic_workflow_success_rate` values across repositories. |
+
+## JSON shape
+
+```json
+{
+  "collection_timestamp": "2026-04-13T01:00:00Z",
+  "repos": [
+    {
+      "repo": "beatlabs/patron",
+      "open_issues": 0,
+      "closed_issues_24h": 0,
+      "open_prs": 0,
+      "merged_prs_24h": 0,
+      "pending_reviews": 0,
+      "ci_pass_rate_7d": 1,
+      "ci_avg_duration_minutes": 4.2,
+      "agentic_workflow_runs_24h": 0,
+      "agentic_workflow_success_rate": null
+    },
+    {
+      "repo": "beatlabs/harvester",
+      "open_issues": 0,
+      "closed_issues_24h": 0,
+      "open_prs": 0,
+      "merged_prs_24h": 0,
+      "pending_reviews": 0,
+      "ci_pass_rate_7d": 0.85,
+      "ci_avg_duration_minutes": 6.1,
+      "agentic_workflow_runs_24h": 0,
+      "agentic_workflow_success_rate": null
+    }
+  ],
+  "cross_repo_summary": {
+    "repo_count": 2,
+    "total_open_issues": 0,
+    "total_closed_issues_24h": 0,
+    "total_open_prs": 0,
+    "total_merged_prs_24h": 0,
+    "total_pending_reviews": 0,
+    "avg_ci_pass_rate_7d": 0.925,
+    "avg_ci_duration_minutes": 5.15,
+    "total_agentic_workflow_runs_24h": 0,
+    "avg_agentic_workflow_success_rate": null
+  }
+}
+```
+
+## Stability rules
+
+- Keep top-level keys stable: `collection_timestamp`, `repos`, `cross_repo_summary`.
+- Keep per-repo metric keys stable for all downstream consumers.
+- Preserve numeric semantics: counts are integers, rates are decimal ratios, durations are minutes.
+- Use `null` instead of inventing placeholder values when data is empty or unavailable.

--- a/.github/workflows/shared/release-notes-template.md
+++ b/.github/workflows/shared/release-notes-template.md
@@ -1,0 +1,34 @@
+---
+description: Shared tag-based release notes template for Go libraries.
+---
+
+# Release Notes Template
+
+Use this template for tag-based GitHub Releases for Go libraries. Include PR links where available and keep each item to a brief, outcome-focused description.
+
+## Breaking Changes
+
+> Put breaking changes first. For every item, include clear migration guidance.
+
+- [#123](https://github.com/OWNER/REPO/pull/123) Brief description of the breaking change.
+  - Migration guidance: What users must change when upgrading.
+
+## New Features
+
+- [#123](https://github.com/OWNER/REPO/pull/123) Brief description of the new capability.
+
+## Improvements
+
+- [#123](https://github.com/OWNER/REPO/pull/123) Brief description of the enhancement.
+
+## Bug Fixes
+
+- [#123](https://github.com/OWNER/REPO/pull/123) Brief description of the fix.
+
+## Dependencies
+
+- [#123](https://github.com/OWNER/REPO/pull/123) Summarize go.mod or go.sum dependency updates.
+
+## Contributors
+
+- @username (first contribution)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Shared prompt fragments live in `shared/` and are pulled in via the `imports:` f
 | Workflow | Schedule | Description |
 |----------|----------|-------------|
 | `org-health-report` | Monthly (1st) | Analyzes issues and PRs for patron and harvester, produces comparative health metrics and an issue report |
+| `metrics-collector` | Daily (1am UTC) | Collects CI, issue, PR, and dependency metrics for patron and harvester, produces JSON + charts |
+| `audit-workflows` | Weekly (Mon 2am UTC) | Audits agentic workflow health across aw-common, patron, and harvester — classifies as healthy/degraded/broken |
 | `stale-repo-identifier` | Monthly (1st) | Scans org repositories for staleness signals and files issues for inactive repos |
 | `ubuntu-image-analyzer` | Monthly (1st) | Analyzes the default Ubuntu Actions runner image and maintains Docker mimic documentation |
 
@@ -32,6 +34,8 @@ Shared prompt fragments live in `shared/` and are pulled in via the `imports:` f
 | `shared/go-security.md` | Go security scanning guidance: govulncheck, gosec, dependency audit, CVE reporting |
 | `shared/issue-triage-go.md` | Go-specific issue triage taxonomy: component classification, priority rules, label scheme |
 | `shared/semver-policy.md` | Semantic versioning policy for Go libraries: breaking change definitions, severity classification, labeling rules |
+| `shared/org-metrics-schema.md` | Stable JSON schema for daily metrics collection: per-repo CI/issue/PR/dependency fields, cross-repo summary |
+| `shared/release-notes-template.md` | Tag-based release notes template: Breaking Changes, Features, Improvements, Bug Fixes, Dependencies, Contributors |
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Phase 3 of the gh-aw rollout — org-level observability and release support.

### New Workflows
- **`metrics-collector`** — Daily (1am UTC) metrics collection for patron + harvester: CI health, issue/PR volume, dependency freshness. Produces JSON + charts.
- **`audit-workflows`** — Weekly (Mon 2am UTC) fleet health audit across aw-common, patron, and harvester. Classifies each workflow as healthy/degraded/broken.

### New Shared Imports
- **`shared/org-metrics-schema.md`** — Stable JSON schema for daily metrics (per-repo + cross-repo fields)
- **`shared/release-notes-template.md`** — Tag-based release notes template (Breaking Changes, Features, Improvements, Bug Fixes, Dependencies, Contributors)

### README
- Updated workflows table with metrics-collector and audit-workflows
- Updated shared imports table with org-metrics-schema and release-notes-template

### QA
- Verify `gh aw compile` succeeds for all new workflows
- Verify `metrics-collector` triggers on schedule and workflow_dispatch
- Verify `audit-workflows` triggers on schedule and workflow_dispatch
- Verify shared imports are resolvable from consumer workflows