### PR TITLE
Phase 4: Weekly org summary

### DIFF
--- a/.github/workflows/weekly-org-summary.md
+++ b/.github/workflows/weekly-org-summary.md
@@ -1,0 +1,255 @@
+---
+description: Weekly organization summary for patron and harvester.
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+permissions:
+  contents: read
+  actions: read
+  issues: read
+  pull-requests: read
+tools:
+  github:
+    lockdown: true
+    toolsets: [repos, issues, pull_requests, actions]
+  cache-memory: true
+  bash:
+    - "*"
+safe-outputs:
+  create-issue:
+    title-prefix: "[weekly-summary]"
+    labels: ["report"]
+    max: 1
+    close-older-issues: true
+  upload-asset:
+    max: 5
+engine: copilot
+strict: true
+timeout-minutes: 30
+network:
+  allowed: [defaults, python]
+imports:
+  - shared/mood.md
+  - shared/python-dataviz.md
+  - shared/trending-charts-simple.md
+  - shared/reporting.md
+---
+
+# Weekly Organization Summary
+
+You are the weekly organization summary agent for exactly these two repositories:
+
+- `beatlabs/patron`
+- `beatlabs/harvester`
+
+## Mission
+
+Produce one concise weekly control-plane summary that is readable for a two-repository fleet and grounded in metrics-collector artifacts plus current GitHub activity.
+
+The summary must:
+
+- Cover only `beatlabs/patron` and `beatlabs/harvester`
+- Focus on the last 7 days of issues, pull requests, and workflow activity
+- Reuse metrics-collector artifacts and cached weekly summaries when available
+- Compare the two repositories side by side
+- Publish exactly one GitHub issue with attached charts
+- Persist this week's summary data for next week's week-over-week comparison
+
+## Current Context
+
+- **Repositories**: `beatlabs/patron`, `beatlabs/harvester`
+- **Time Window**: Last 7 days
+- **Downstream Inputs**: metrics-collector artifacts and prior weekly-summary cache-memory entries
+- **Output Mode**: GitHub issue via safe-output
+- **Persistence**: Use cache-memory for trend continuity, retry safety, and week-over-week comparison
+
+## Execution Plan
+
+### Phase 0: Setup
+
+Create working directories before collecting data:
+
+```bash
+mkdir -p /tmp/gh-aw/weekly-summary
+mkdir -p /tmp/gh-aw/weekly-summary/charts
+```
+
+### Phase 1: Collect Weekly Repository Activity
+
+**Goal**: Gather exactly 7 days of issue, PR, and workflow-run activity for `beatlabs/patron` and `beatlabs/harvester`.
+
+For each repository, collect and persist raw data separately.
+
+1. **Issues**
+   - Fetch issues opened in the last 7 days
+   - Fetch issues closed in the last 7 days
+   - Preserve enough fields for later analysis: number, title, state, created date, closed date, updated date, author, labels, assignees, comments count, URL, and repository name
+   - Save raw issue data to repository-specific files under `/tmp/gh-aw/weekly-summary/`
+
+2. **Pull Requests**
+   - Fetch pull requests opened in the last 7 days
+   - Fetch pull requests merged in the last 7 days
+   - Fetch pull requests closed in the last 7 days
+   - Preserve enough fields for later analysis: number, title, state, created date, closed date, merged date, author, comments or review-discussion counts if available, URL, and repository name
+   - Save raw PR data to repository-specific files under `/tmp/gh-aw/weekly-summary/`
+
+3. **Workflow Runs**
+   - Fetch workflow runs from the last 7 days for each repository
+   - Compute and preserve success and failure counts
+   - Retain run-level metadata needed to identify notable workflows, durations if available, and whether runs appear agentic or control-plane related
+   - Save raw workflow-run data to repository-specific files under `/tmp/gh-aw/weekly-summary/`
+
+4. **Rate limiting**
+   - Add a **5 second delay between repository queries**
+   - Apply the delay consistently across issue, PR, and workflow-run collection phases
+   - If rate-limit pressure appears, retry conservatively rather than broadening scope
+
+5. **Metrics-collector inputs**
+   - Retrieve relevant metrics-collector artifacts from recent runs
+   - Reuse the artifact schema rather than inventing a new schema when equivalent daily metrics already exist
+   - Prefer artifact data as the baseline input for CI, workflow, and activity trend calculations where appropriate
+
+6. **Historical context from cache-memory**
+   - Check cache-memory for prior weekly summaries
+   - Check cache-memory for persisted metrics-collector trend inputs or normalized weekly snapshots
+   - Use prior data only to compute week-over-week deltas; do not expand repository scope beyond the two required repositories
+
+### Phase 2: Analyze with Python and pandas
+
+Use Python with pandas to turn raw activity and metrics artifacts into concise weekly comparisons.
+
+Perform the following analysis:
+
+1. **Per-repo metrics**
+   - Issue velocity for each repository
+   - PR throughput for each repository
+   - CI stability for each repository
+
+2. **Week-over-week deltas**
+   - If prior weekly data exists in cache-memory, compute deltas for the main issue, PR, CI, and workflow metrics
+   - If prior data does not exist, state that clearly and continue without failing
+
+3. **Highlight items**
+   - Identify the biggest PR merged during the week using a reasonable significance heuristic such as discussion volume, review activity, or change impact if available
+   - Identify the most-discussed issue during the week
+   - Identify any security findings surfaced by issues, PRs, workflow outputs, or metrics artifacts
+
+4. **Agentic workflow effectiveness**
+   - Determine how many workflow-generated issues or PRs were acted on during the week
+   - Summarize which workflows produced actionable outputs and whether those outputs led to follow-up activity
+
+5. **Output discipline**
+   - Save normalized summary data and any derived tables to `/tmp/gh-aw/weekly-summary/`
+   - Keep the data model stable enough to persist into cache-memory for next week's comparison
+
+### Phase 3: Generate Charts
+
+Create concise charts that support the weekly issue report.
+
+Required charts:
+
+1. **Issue and PR activity comparison**
+   - Compare `patron` and `harvester` on weekly issue and PR activity in one readable chart or compact set of charts
+
+2. **CI pass rate trend**
+   - Generate a CI pass rate trend chart if historical data is available
+   - If not enough history exists, skip the trend chart gracefully rather than fabricating one
+
+Save all charts to:
+
+```text
+/tmp/gh-aw/weekly-summary/charts/
+```
+
+### Phase 4: Build the Weekly Summary Issue
+
+Create a GitHub issue with a concise but decision-useful structure.
+
+Use exactly these sections:
+
+1. **Week at a Glance**
+   - 3 to 5 bullet executive summary
+
+2. **Patron This Week**
+   - issues
+   - PRs
+   - CI health
+   - notable items
+
+3. **Harvester This Week**
+   - issues
+   - PRs
+   - CI health
+   - notable items
+
+4. **Side-by-Side Comparison**
+   - table of key metrics for both repositories
+
+5. **Agentic Workflow Report**
+   - which workflows ran
+   - success and failure counts
+   - notable outputs
+
+6. **Week-over-Week Trends**
+   - deltas from the prior week if data is available
+   - otherwise explicitly note that no prior weekly baseline was found
+
+7. **Action Items**
+   - maximum 3 concrete recommendations
+
+Keep the issue readable:
+
+- Prefer short interpretation over raw dumps
+- Use tables where comparison helps
+- Include links to notable issues, PRs, and workflow runs when available
+- Call out security-relevant findings explicitly if any exist
+
+### Phase 5: Publish Outputs
+
+1. Create exactly one `[weekly-summary]` issue in aw-common using the safe-output channel.
+2. Upload generated chart images as assets.
+3. Store this week's normalized summary data in cache-memory so the next run can compute week-over-week trends.
+4. Ensure older weekly-summary issues are auto-closed through the configured safe-output behavior.
+
+## Data Handling Guidelines
+
+### Scope Control
+
+- Do not query or reference any repository other than `beatlabs/patron` and `beatlabs/harvester`
+- Keep all metrics, charts, and commentary attributable to one of those two repositories or to their shared control-plane workflows
+
+### Trend Inputs
+
+- Prefer metrics-collector artifacts for baseline metrics when they already contain the needed daily measurements
+- Use cache-memory to bridge daily artifacts into a weekly narrative
+- Preserve enough structured output so next week's run can compare against this week's values without recomputing everything from scratch
+
+### Error Handling
+
+- Save intermediate raw and normalized data files
+- Handle missing artifacts, partial workflow-run history, and absent historical baselines gracefully
+- Continue with the best available data rather than failing on sparse inputs
+- Log fallbacks clearly in the report or final summary where relevant
+
+### Report Quality
+
+- Keep the final issue concise and readable
+- Make the `patron` versus `harvester` comparison explicit
+- Focus on operationally useful signals: throughput, stability, notable work, and follow-through on agentic outputs
+- Avoid over-explaining implementation details; prioritize outcomes and interpretation
+
+## Success Criteria
+
+A successful weekly summary:
+
+- ✅ analyzes exactly `beatlabs/patron` and `beatlabs/harvester`
+- ✅ uses metrics-collector artifacts plus current 7-day GitHub activity
+- ✅ computes per-repo issue, PR, CI, and workflow metrics
+- ✅ includes week-over-week deltas when historical cache data exists
+- ✅ identifies notable items and agentic workflow effectiveness
+- ✅ generates charts and uploads them as assets
+- ✅ creates one concise `[weekly-summary]` issue
+- ✅ persists this week's summary data for the next weekly run
+
+Begin the weekly organization summary now. Follow the phases in order, keep the scope tight to `patron` and `harvester`, and produce a concise weekly control-plane report.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Shared prompt fragments live in `shared/` and are pulled in via the `imports:` f
 | `org-health-report` | Monthly (1st) | Analyzes issues and PRs for patron and harvester, produces comparative health metrics and an issue report |
 | `metrics-collector` | Daily (1am UTC) | Collects CI, issue, PR, and dependency metrics for patron and harvester, produces JSON + charts |
 | `audit-workflows` | Weekly (Mon 2am UTC) | Audits agentic workflow health across aw-common, patron, and harvester — classifies as healthy/degraded/broken |
+| `weekly-org-summary` | Weekly (Mon 9am UTC) | Concise weekly control-plane summary for patron and harvester — activity, CI health, agentic workflow effectiveness |
 | `stale-repo-identifier` | Monthly (1st) | Scans org repositories for staleness signals and files issues for inactive repos |
 | `ubuntu-image-analyzer` | Monthly (1st) | Analyzes the default Ubuntu Actions runner image and maintains Docker mimic documentation |
 


### PR DESCRIPTION
## Summary

Phase 4 of the gh-aw rollout — weekly control-plane reporting.

### New Workflow
- **`weekly-org-summary`** — Weekly (Mon 9am UTC): concise summary of patron + harvester activity, CI health, agentic workflow effectiveness, with week-over-week trends and charts. Consumes metrics-collector artifacts.

### README
- Updated workflows table with weekly-org-summary

### QA
- Verify `gh aw compile` succeeds
- Verify triggers on schedule (Mon 9am UTC) and workflow_dispatch
- Verify report scopes to exactly patron and harvester
- Verify cache-memory persistence for week-over-week trends
- Verify auto-close of older `[weekly-summary]` issues